### PR TITLE
perf: agregar indices compuestos y unique constraint en BD #53

### DIFF
--- a/database/migrations/2026_08_15_043158_add_performance_indexes.php
+++ b/database/migrations/2026_08_15_043158_add_performance_indexes.php
@@ -1,0 +1,48 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->index(['doctor_id', 'appointment_date'], 'idx_doctor_date');
+            $table->index(['patient_id', 'status'], 'idx_patient_status');
+        });
+
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->index(['action', 'created_at'], 'idx_action_created');
+            $table->index(['model_type', 'model_id'], 'idx_model');
+        });
+
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->unique(['doctor_id', 'date', 'start_time'], 'uq_doctor_slot');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('appointments', function (Blueprint $table) {
+            $table->dropIndex('idx_doctor_date');
+            $table->dropIndex('idx_patient_status');
+        });
+
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->dropIndex('idx_action_created');
+            $table->dropIndex('idx_model');
+        });
+
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->dropUnique('uq_doctor_slot');
+        });
+    }
+};


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

## 📌 Resumen del Cambio
Se agrega una migración con índices compuestos en `appointments` y `activity_logs` para acelerar las consultas más frecuentes (agenda por doctor y fecha, filtros de logs), y un unique constraint en `schedules` que previene horarios duplicados del mismo doctor a nivel de base de datos.

## 🔍 Tipo de Cambio realizado
- [x] 🚀 Mejora de rendimiento (`perf`)

## 📂 Archivos Afectados
- `database/migrations/2026_08_15_043158_add_performance_indexes.php`

## 🧪 ¿Cómo Probarlo?
1. Ejecutar `php artisan migrate`
2. En `php artisan tinker`, correr `DB::select("SHOW INDEX FROM appointments WHERE Key_name = 'idx_doctor_date'")` → debe devolver el índice
3. Insertar un schedule y luego repetir el mismo insert (mismo doctor_id, date, start_time) → el segundo debe lanzar `UniqueConstraintViolationException`
4. `php artisan migrate:rollback` revierte los índices sin error

## ✅ Checklist
- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

## 📎 Notas Adicionales

Closes #53
<img width="1833" height="1199" alt="Captura desde 2026-08-14 21-34-58" src="https://github.com/user-attachments/assets/8ff0aa50-e853-44d3-ae59-b65bbc87c7f6" />


Este constraint complementa a la tarjeta AS3 (Andrade): cuando migre ScheduleController de sesión a Eloquent, el unique constraint ya queda protegiendo contra horarios duplicados a nivel de BD.