### PR TITLE
feat: implementar PatientProfileController con show, update, updatePh…

### DIFF
--- a/app/Http/Controllers/PatientProfileController.php
+++ b/app/Http/Controllers/PatientProfileController.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\ActivityLog;
+use App\Models\PatientProfile;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+
+class PatientProfileController extends Controller
+{
+	/**
+	 * Ver el perfil médico del paciente autenticado.
+	 */
+	public function show(Request $request): JsonResponse
+	{
+		$profile = $this->profileForUser($request->user());
+
+		return response()->json([
+			'profile' => $this->formatProfile($profile),
+		]);
+	}
+
+	/**
+	 * Actualizar el perfil médico del paciente autenticado.
+	 */
+	public function update(Request $request): JsonResponse
+	{
+		$validated = $request->validate([
+			'birth_date' => ['nullable', 'date'],
+			'blood_type' => ['nullable', 'in:A+,A-,B+,B-,AB+,AB-,O+,O-'],
+			'allergies' => ['nullable', 'string', 'max:2000'],
+			'chronic_conditions' => ['nullable', 'string', 'max:2000'],
+			'emergency_contact_name' => ['nullable', 'string', 'max:150'],
+			'emergency_contact_phone' => ['nullable', 'string', 'max:20'],
+			'curp' => ['nullable', 'string', 'size:18', 'alpha_num'],
+		]);
+
+		$user = $request->user();
+		$profile = $this->profileForUser($user);
+
+		// curp única, sin contar el propio perfil
+		if (!empty($validated['curp'])) {
+			$curpExists = PatientProfile::where('curp', $validated['curp'])
+				->where('id', '!=', $profile->id)
+				->exists();
+
+			if ($curpExists) {
+				return response()->json([
+					'message' => 'Ya existe un paciente registrado con ese CURP.',
+					'errors' => [
+						'curp' => ['Este CURP ya está en uso.'],
+					],
+				], 422);
+			}
+		}
+
+		$oldValues = $profile->only(array_keys($validated));
+
+		$profile->update($validated);
+
+		ActivityLog::create([
+			'user_id' => $user->id,
+			'action' => 'update',
+			'model_type' => PatientProfile::class,
+			'model_id' => $profile->id,
+			'description' => 'El paciente actualizó su perfil médico',
+			'ip_address' => $request->ip(),
+			'user_agent' => $request->userAgent(),
+			'old_values' => $oldValues,
+			'new_values' => $validated,
+		]);
+
+		return response()->json([
+			'message' => 'Perfil médico actualizado correctamente.',
+			'profile' => $this->formatProfile($profile->fresh()),
+		]);
+	}
+
+	/**
+	 * Subir/actualizar la foto de perfil del paciente autenticado.
+	 */
+	public function updatePhoto(Request $request): JsonResponse
+	{
+		$validated = $request->validate([
+			'photo' => ['required', 'image', 'max:4096'], // máx 4MB
+		]);
+
+		$user = $request->user();
+		$profile = $this->profileForUser($user);
+
+		// Borrar foto anterior si existía
+		if ($profile->photo_path && Storage::disk('public')->exists($profile->photo_path)) {
+			Storage::disk('public')->delete($profile->photo_path);
+		}
+
+		$path = $request->file('photo')->store('patient_photos', 'public');
+
+		$profile->update(['photo_path' => $path]);
+
+		ActivityLog::create([
+			'user_id' => $user->id,
+			'action' => 'update',
+			'model_type' => PatientProfile::class,
+			'model_id' => $profile->id,
+			'description' => 'El paciente actualizó su foto de perfil',
+			'ip_address' => $request->ip(),
+			'user_agent' => $request->userAgent(),
+		]);
+
+		return response()->json([
+			'message' => 'Foto de perfil actualizada correctamente.',
+			'profile' => $this->formatProfile($profile->fresh()),
+		]);
+	}
+
+	/**
+	 * Ver el perfil médico de un paciente específico (solo doctor).
+	 */
+	public function showForDoctor(Request $request, int $id): JsonResponse
+	{
+		$patient = User::role('patient')->findOrFail($id);
+		$profile = $this->profileForUser($patient);
+
+		return response()->json([
+			'profile' => $this->formatProfile($profile),
+		]);
+	}
+
+	/**
+	 * Obtiene (o crea) el perfil médico de un usuario.
+	 */
+	private function profileForUser(User $user): PatientProfile
+	{
+		return PatientProfile::firstOrCreate(['user_id' => $user->id]);
+	}
+
+	/**
+	 * Da forma a la respuesta JSON del perfil, incluyendo la URL pública de la foto.
+	 */
+	private function formatProfile(PatientProfile $profile): array
+	{
+		return [
+			'id' => $profile->id,
+			'user_id' => $profile->user_id,
+			'birth_date' => $profile->birth_date,
+			'blood_type' => $profile->blood_type,
+			'allergies' => $profile->allergies,
+			'chronic_conditions' => $profile->chronic_conditions,
+			'emergency_contact_name' => $profile->emergency_contact_name,
+			'emergency_contact_phone' => $profile->emergency_contact_phone,
+			'curp' => $profile->curp,
+			'photo_url' => $profile->photo_path
+				? Storage::disk('public')->url($profile->photo_path)
+				: null,
+		];
+	}
+}

--- a/app/Models/PatientProfile.php
+++ b/app/Models/PatientProfile.php
@@ -15,6 +15,7 @@ class PatientProfile extends Model
 		'emergency_contact_name',
 		'emergency_contact_phone',
 		'curp',
+		'photo_path',
 	];
 
 	public function user()

--- a/database/migrations/2026_08_19_031109_add_photo_path_to_patient_profiles_table.php
+++ b/database/migrations/2026_08_19_031109_add_photo_path_to_patient_profiles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('patient_profiles', function (Blueprint $table) {
+            $table->string('photo_path')->nullable()->after('curp');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('patient_profiles', function (Blueprint $table) {
+            $table->dropColumn('photo_path');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\DoctorProfileController;
 use App\Http\Controllers\ScheduleController;
 use App\Http\Controllers\GoogleCalendarController;
 use App\Http\Controllers\SpecialtyController;
+use App\Http\Controllers\PatientProfileController;
 use App\Models\User;
 
 Route::get('/', function () {
@@ -106,11 +107,15 @@ Route::middleware(['auth', 'role:doctor'])->group(function () {
 	Route::get('/doctor/perfil/data', [DoctorProfileController::class, 'indexData'])->name('doctor.profile.data');
 	Route::patch('/doctor/perfil', [DoctorProfileController::class, 'update'])->name('doctor.profile.update');
 	Route::post('/doctor/perfil/photo', [DoctorProfileController::class, 'updatePhoto'])->name('doctor.profile.photo');
+	Route::get('/doctor/pacientes/{id}/perfil', [PatientProfileController::class, 'showForDoctor'])->name('doctor.patient.profile');
 });
 
 Route::middleware(['auth', 'role:patient'])->group(function () {
 	Route::get('/patient/dashboard', [DashboardController::class, 'index'])->name('patient.dashboard');
 	Route::get('/patient/dashboard/data', [DashboardController::class, 'patientData'])->name('patient.dashboard.data');
+	Route::get('/patient/perfil/data', [PatientProfileController::class, 'show'])->name('patient.profile.data');
+	Route::patch('/patient/perfil', [PatientProfileController::class, 'update'])->name('patient.profile.update');
+	Route::post('/patient/perfil/photo', [PatientProfileController::class, 'updatePhoto'])->name('patient.profile.photo');
 });
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

## 📌 Resumen del Cambio
Se implementa `PatientProfileController` con persistencia real en base de datos (Eloquent, no sesión) para que el paciente pueda gestionar su perfil médico: datos personales, tipo de sangre, alergias, condiciones crónicas y contacto de emergencia. Se agrega una migración para la columna `photo_path` (no existía en la tabla original) y el flujo completo de subida de foto con Laravel Storage. También se agrega el endpoint para que el doctor consulte el perfil médico de un paciente antes de la consulta.

## 🔍 Tipo de Cambio realizado
- [x] ✨ Nueva funcionalidad (`feat`)

## 📂 Archivos Afectados
- `app/Http/Controllers/PatientProfileController.php` (nuevo)
- `app/Models/PatientProfile.php`
- `database/migrations/2026_08_19_031109_add_photo_path_to_patient_profiles_table.php` (nuevo)
- `routes/web.php`

## 🧪 ¿Cómo Probarlo?
1. Ejecutar `php artisan migrate`
2. En `php artisan tinker`: crear/actualizar un perfil con `PatientProfile::firstOrCreate(['user_id' => $patient->id])->update([...])` → verificar con `DB::table('patient_profiles')` que persiste en BD real
3. Validar `blood_type` fuera del ENUM (ej. "ZZ") → debe rechazar con `Validator::make(...)->fails() === true`
4. Insertar un CURP repetido → debe rechazar por duplicado
5. Probar `updatePhoto()`: guardar un archivo con `store('patient_photos', 'public')` y confirmar que `photo_path` persiste tras `update()`
6. Login como doctor (`doctor@test.com`) y visitar `/doctor/pacientes/{id}/perfil` → debe devolver el perfil médico del paciente en JSON
7. Un paciente solo puede editar su propio perfil, ya que `show()`/`update()`/`updatePhoto()` siempre operan sobre `$request->user()` — estructuralmente no hay forma de editar el perfil de otro paciente

## ✅ Checklist
- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

## 📎 Notas Adicionales
<img width="1912" height="1199" alt="Captura desde 2026-08-18 20-31-50" src="https://github.com/user-attachments/assets/ddf0fc2d-a108-4ddd-802c-47718b67b19a" />
<img width="1912" height="1199" alt="Captura desde 2026-08-18 20-30-14" src="https://github.com/user-attachments/assets/1137a0fb-03fd-4734-8e5a-573fc80bc4ab" />
<img width="1907" height="792" alt="Captura desde 2026-08-18 20-22-31" src="https://github.com/user-attachments/assets/ec9df3ec-b466-44ef-9f0b-fbce9d37cc09" />
<img width="1424" height="842" alt="Captura desde 2026-08-18 20-20-07" src="https://github.com/user-attachments/assets/2a268c1a-356d-44f4-a562-c422bc08cba2" />


Closes #31

Desviación documentada respecto al issue original: la tarjeta pedía rutas protegidas con `$user->can('permiso')` (Spatie Permissions), pero los permisos aún no están sembrados en el proyecto (issue #8, pendiente). Por consistencia con el resto del código actual, las rutas se protegieron con `role:patient` / `role:doctor` (mismo patrón que ya usa toda la app). Se recomienda migrar a permisos específicos cuando el #8 esté resuelto.

Este es el primer controlador del proyecto que persiste fotos en storage real (`Storage::disk('public')`), en vez de guardarlas en sesión como los módulos aún pendientes de migrar (AS3/AS4).