### PR TITLE
security: implementar CORS, headers de seguridad, password fuerte y g…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,9 @@
 /public/storage
 /storage/*.key
 /storage/pail
-/docs
+/docs/coverage
+/docs/*
+!/docs/*.md
 /vendor
 Homestead.json
 Homestead.yaml

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -3,13 +3,12 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RegisterRequest;
 use App\Models\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules;
 use Illuminate\View\View;
 
 class RegisteredUserController extends Controller
@@ -24,21 +23,15 @@ class RegisteredUserController extends Controller
 
     /**
      * Handle an incoming registration request.
-     *
-     * @throws \Illuminate\Validation\ValidationException
      */
-    public function store(Request $request): RedirectResponse
+    public function store(RegisterRequest $request): RedirectResponse
     {
-        $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
+        $validated = $request->validated();
 
         $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'name' => $validated['name'],
+            'email' => $validated['email'],
+            'password' => Hash::make($validated['password']),
         ]);
 
         event(new Registered($user));

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class SecurityHeaders
+{
+	/**
+	 * Handle an incoming request.
+	 *
+	 * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+	 */
+	public function handle(Request $request, Closure $next): Response
+	{
+		$response = $next($request);
+
+		$response->headers->set('X-Frame-Options', 'SAMEORIGIN');
+		$response->headers->set('X-Content-Type-Options', 'nosniff');
+		$response->headers->set('Referrer-Policy', 'strict-origin-when-cross-origin');
+		$response->headers->set('X-XSS-Protection', '1; mode=block');
+
+		// En local, el servidor de Vite (npm run dev) sirve los assets desde
+		// otro origen (127.0.0.1:5173) para hot-reload. En producción los
+		// assets ya están compilados y se sirven desde el mismo dominio,
+		// por lo que esa excepción no aplica ni hace falta.
+		$viteDevServer = app()->environment('local')
+			? '127.0.0.1:5173 localhost:5173 ws://127.0.0.1:5173 ws://localhost:5173'
+			: '';
+
+		$response->headers->set(
+			'Content-Security-Policy',
+			"default-src 'self'; " .
+				"script-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com {$viteDevServer}; " .
+				"style-src 'self' 'unsafe-inline' cdn.jsdelivr.net cdnjs.cloudflare.com fonts.bunny.net {$viteDevServer}; " .
+				"font-src 'self' cdnjs.cloudflare.com fonts.bunny.net; " .
+				"img-src 'self' data: blob:; " .
+				"connect-src 'self' cdnjs.cloudflare.com {$viteDevServer};"
+		);
+
+		return $response;
+	}
+}

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Requests\Auth;
+
+use App\Models\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules\Password;
+
+class RegisterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'password' => [
+                'required',
+                'confirmed',
+                Password::min(8)
+                    ->mixedCase()
+                    ->numbers()
+                    ->symbols(),
+            ],
+        ];
+    }
+
+    /**
+     * Mensajes de error personalizados.
+     */
+    public function messages(): array
+    {
+        return [
+            'password.min' => 'La contraseña debe tener al menos 8 caracteres.',
+        ];
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -16,6 +16,8 @@ return Application::configure(basePath: dirname(__DIR__))
 			'permission' => \Spatie\Permission\Middleware\PermissionMiddleware::class,
 			'role_or_permission' => \Spatie\Permission\Middleware\RoleOrPermissionMiddleware::class,
 		]);
+
+		$middleware->append(\App\Http\Middleware\SecurityHeaders::class);
 	})
 	->withExceptions(function (Exceptions $exceptions): void {
 		//

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+
+	/*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Solo se permiten los orígenes explícitamente listados abajo. Antes de
+    | este cambio, Laravel usaba el default de fábrica (allowed_origins: '*'),
+    | permitiendo peticiones desde cualquier dominio. Como todo el frontend
+    | vive en el mismo Laravel (Blade + Bootstrap, sin SPA separado), solo se
+    | permite el propio dominio de la app.
+    |
+    */
+
+	'paths' => ['*'],
+
+	'allowed_methods' => ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+
+	'allowed_origins' => [
+		env('APP_URL', 'http://localhost:8000'),
+		'https://medschedule-production.up.railway.app',
+	],
+
+	'allowed_origins_patterns' => [],
+
+	'allowed_headers' => ['*'],
+
+	'exposed_headers' => [],
+
+	'max_age' => 0,
+
+	'supports_credentials' => true,
+
+];

--- a/docs/security-guidelines.md
+++ b/docs/security-guidelines.md
@@ -1,0 +1,47 @@
+# Guía de seguridad — MedSchedule
+
+Este documento resume las prácticas de seguridad que el equipo debe seguir al desarrollar nuevas vistas y endpoints.
+
+## 1. Protección XSS (Cross-Site Scripting)
+
+**Regla de oro: nunca usar `{!! !!}` con datos que vengan del usuario o de la base de datos.**
+
+Blade escapa automáticamente cualquier variable impresa con doble llave:
+
+```blade
+{{-- ✅ CORRECTO: Blade escapa el contenido automáticamente --}}
+<p>{{ $paciente->allergies }}</p>
+
+{{-- ❌ INCORRECTO: {!! !!} imprime HTML crudo, sin escapar --}}
+<p>{!! $paciente->allergies !!}</p>
+```
+
+Si un paciente escribe en el campo de alergias algo como `<script>alert('hackeado')</script>`, con `{{ }}` el navegador lo muestra como texto plano; con `{!! !!}` lo ejecutaría como código.
+
+**¿Cuándo SÍ usar `{!! !!}`?** Solo cuando el contenido es HTML de confianza generado por el propio sistema (por ejemplo, un editor de texto enriquecido validado en el backend), nunca con texto libre de un formulario.
+
+**En JavaScript:** al insertar datos dinámicos en el DOM, usar `textContent` en vez de `innerHTML`:
+
+```js
+// ✅ CORRECTO
+elemento.textContent = datos.nombre;
+
+// ❌ INCORRECTO — vulnerable si "datos.nombre" viene del usuario
+elemento.innerHTML = datos.nombre;
+```
+
+## 2. CORS
+
+Los orígenes permitidos están restringidos en `config/cors.php`. Si se agrega un nuevo dominio (por ejemplo, un subdominio de staging), debe añadirse explícitamente ahí — nunca usar `'*'` en `allowed_origins`.
+
+## 3. Contraseñas
+
+Todo formulario de registro o cambio de contraseña debe usar `Illuminate\Validation\Rules\Password` con mínimo 8 caracteres, mayúscula/minúscula, número y símbolo (ver `app/Http/Requests/Auth/RegisterRequest.php` como referencia).
+
+## 4. Headers de seguridad
+
+Los headers (CSP, X-Frame-Options, etc.) se aplican automáticamente a todas las respuestas vía `App\Http\Middleware\SecurityHeaders`. Si una vista nueva necesita cargar un recurso externo (CDN, fuente, script), debe agregarse explícitamente a la política en ese middleware — no relajar el CSP de forma global.
+
+## 5. Validación de datos
+
+Usar siempre `FormRequest` para validar entradas de formularios (no `$request->validate()` inline en el controlador), siguiendo el patrón de `LoginRequest`, `RegisterRequest` y `ProfileUpdateRequest`.


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

## 📌 Resumen del Cambio
Se implementan los mecanismos de seguridad del sistema: restricción de CORS a orígenes específicos (antes permitía cualquier dominio), headers de seguridad HTTP (CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy) aplicados globalmente, validación de contraseñas fuertes mediante un FormRequest dedicado, y una guía de protección XSS documentada para el equipo.

## 🔍 Tipo de Cambio realizado
- [x] ✨ Nueva funcionalidad (`feat`)
- [x] 🔒 Otro (especificar): Corrección de seguridad (`security`)

## 📂 Archivos Afectados
- `config/cors.php` (nuevo)
- `app/Http/Requests/Auth/RegisterRequest.php` (nuevo)
- `app/Http/Controllers/Auth/RegisteredUserController.php`
- `app/Http/Middleware/SecurityHeaders.php` (nuevo)
- `bootstrap/app.php`
- `docs/security-guidelines.md` (nuevo)
- `.gitignore`

## 🧪 ¿Cómo Probarlo?
1. En `php artisan tinker`: `config('cors.allowed_origins')` → debe devolver solo los orígenes permitidos, no `*`
2. Validar una contraseña débil (ej. `abc123`) contra `Password::min(8)->mixedCase()->numbers()->symbols()` → debe rechazar; con `MiClave123!` debe aceptar
3. `curl -I http://localhost:8000` → debe incluir los headers `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy` y `Content-Security-Policy`
4. Navegar por el sitio con `npm run dev` corriendo y revisar la consola del navegador → sin errores de CSP bloqueando recursos
5. Revisar `docs/security-guidelines.md` para la guía de XSS documentada

## ✅ Checklist
- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

## 📎 Notas Adicionales

Closes #18 (parcial)
<img width="1912" height="1199" alt="Captura desde 2026-08-18 21-42-11" src="https://github.com/user-attachments/assets/4ff02d66-b36c-4dae-b806-58e75eec8950" />
<img width="1912" height="1199" alt="Captura desde 2026-08-18 21-33-20" src="https://github.com/user-attachments/assets/9e7a8e04-3873-4463-b754-51fe7ed26959" />


Se completaron 4 de los 5 criterios de aceptación: CORS, headers de seguridad, contraseña fuerte en FormRequest, y guía XSS documentada. **Pendiente:** el análisis en MDN Observatory requiere el sitio desplegado y público, y Railway sigue offline por el trial vencido (issue de infraestructura ajeno a esta tarjeta). Se completará en cuanto el equipo resuelva el acceso a Railway.

El CSP incluye una excepción condicional solo en entorno `local` para permitir el servidor de desarrollo de Vite (hot-reload); en producción esa excepción se desactiva automáticamente y el CSP queda más estricto.