### PR TITLE
perf: mover sincronizacion con Google Calendar a cola con reintentos #54

### DIFF
--- a/app/Http/Controllers/GoogleCalendarController.php
+++ b/app/Http/Controllers/GoogleCalendarController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\SyncAppointmentToCalendar;
 use App\Models\Appointment;
 use App\Services\GoogleCalendarService;
 use Illuminate\Http\Request;
@@ -12,12 +13,11 @@ class GoogleCalendarController extends Controller
 	public function __construct(private GoogleCalendarService $calendar) {}
 
 	/**
-	 * Sincronizar cita con Google Calendar
+	 * Sincronizar cita con Google Calendar (asíncrono, vía cola)
 	 */
 	public function sync(int $appointmentId)
 	{
-		$appointment = Appointment::with(['doctor', 'patient', 'specialty'])
-			->findOrFail($appointmentId);
+		$appointment = Appointment::findOrFail($appointmentId);
 
 		// Solo el doctor dueño o admin puede sincronizar
 		$user = Auth::user();
@@ -31,19 +31,11 @@ class GoogleCalendarController extends Controller
 			], 422);
 		}
 
-		$eventId = $this->calendar->createEvent($appointment);
-
-		if ($eventId) {
-			$appointment->update(['google_event_id' => $eventId]);
-			return response()->json([
-				'message'        => 'Cita sincronizada con Google Calendar.',
-				'google_event_id' => $eventId,
-			]);
-		}
+		SyncAppointmentToCalendar::dispatch($appointment->id);
 
 		return response()->json([
-			'message' => 'No se pudo sincronizar con Google Calendar.',
-		], 500);
+			'message' => 'Sincronización con Google Calendar en proceso.',
+		]);
 	}
 
 	/**

--- a/app/Jobs/SyncAppointmentToCalendar.php
+++ b/app/Jobs/SyncAppointmentToCalendar.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Appointment;
+use App\Services\GoogleCalendarService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+
+class SyncAppointmentToCalendar implements ShouldQueue
+{
+	use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+	/**
+	 * Número de intentos antes de marcar el job como fallido.
+	 */
+	public int $tries = 3;
+
+	/**
+	 * Segundos de espera entre cada reintento.
+	 */
+	public int $backoff = 10;
+
+	public function __construct(private int $appointmentId) {}
+
+	/**
+	 * Execute the job.
+	 */
+	public function handle(GoogleCalendarService $calendar): void
+	{
+		$appointment = Appointment::with(['doctor', 'patient', 'specialty'])
+			->find($this->appointmentId);
+
+		if (!$appointment) {
+			Log::warning("SyncAppointmentToCalendar: cita {$this->appointmentId} ya no existe.");
+			return;
+		}
+
+		if ($appointment->status !== 'confirmed') {
+			Log::info("SyncAppointmentToCalendar: cita {$this->appointmentId} ya no está confirmada, se omite.");
+			return;
+		}
+
+		$eventId = $calendar->createEvent($appointment);
+
+		if ($eventId) {
+			$appointment->update(['google_event_id' => $eventId]);
+		} else {
+			// createEvent() devolvió null (fallo controlado) — se relanza
+			// para que el mecanismo de reintentos de la cola actúe.
+			throw new \RuntimeException(
+				"No se pudo crear el evento en Google Calendar para la cita {$this->appointmentId}."
+			);
+		}
+	}
+
+	/**
+	 * Se ejecuta si el job agota todos los reintentos sin éxito.
+	 */
+	public function failed(\Throwable $exception): void
+	{
+		Log::error("SyncAppointmentToCalendar falló definitivamente para la cita {$this->appointmentId}: {$exception->getMessage()}");
+	}
+}

--- a/database/migrations/2026_08_19_045433_create_failed_jobs_table.php
+++ b/database/migrations/2026_08_19_045433_create_failed_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('failed_jobs');
+    }
+};

--- a/database/migrations/2026_08_19_045433_create_jobs_table.php
+++ b/database/migrations/2026_08_19_045433_create_jobs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('jobs', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('queue')->index();
+            $table->longText('payload');
+            $table->unsignedTinyInteger('attempts');
+            $table->unsignedInteger('reserved_at')->nullable();
+            $table->unsignedInteger('available_at');
+            $table->unsignedInteger('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('jobs');
+    }
+};


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

## 📌 Resumen del Cambio
Se mueve la sincronización de citas con Google Calendar a un Job en cola (`SyncAppointmentToCalendar`), en lugar de una llamada HTTP síncrona dentro del request de confirmación. Se crean las tablas `jobs` y `failed_jobs` (no existían, `QUEUE_CONNECTION=database` estaba configurado sin infraestructura de cola real detrás). El Job incluye reintentos automáticos con backoff si Google falla.

## 🔍 Tipo de Cambio realizado
- [x] 🚀 Mejora de rendimiento (`perf`)

## 📂 Archivos Afectados
- `app/Jobs/SyncAppointmentToCalendar.php` (nuevo)
- `app/Http/Controllers/GoogleCalendarController.php`
- `database/migrations/2026_08_19_045433_create_jobs_table.php` (nuevo)
- `database/migrations/2026_08_19_045433_create_failed_jobs_table.php` (nuevo)

## 🧪 ¿Cómo Probarlo?
1. `php artisan migrate` (crea las tablas `jobs` y `failed_jobs`)
2. En `php artisan tinker`: `SyncAppointmentToCalendar::dispatch($appointmentId)` de una cita confirmada → verificar con `DB::table('jobs')->count()` que se encoló (no se ejecuta inline)
3. `php artisan queue:work --tries=3` → procesa el job; si falla (ej. sin credenciales de Google en local), reintenta automáticamente con backoff de 10s antes de caer en `failed_jobs`
4. Confirmar que `GoogleCalendarController::sync()` responde de inmediato al usuario, sin esperar la respuesta de Google
5. En producción (con credenciales reales y worker corriendo), el evento debe aparecer en Google Calendar segundos después y `google_event_id` debe persistir en la cita

## ✅ Checklist
- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

## 📎 Notas Adicionales
Closes #54 (parcial)

Se validaron 2 de los 3 criterios con evidencia real: el dispatch no bloquea el request, y el mecanismo de reintentos funciona correctamente (probado provocando fallos reales por falta de credenciales de Google en el entorno local — el job reintentó 3 veces con backoff antes de caer en `failed_jobs`, sin romper la respuesta al usuario).

**Pendiente:** confirmar que el evento aparece en Google Calendar en un entorno con credenciales reales — no se puede validar en local. Falta además levantar `php artisan queue:work` como proceso persistente en Railway (bloqueado por el trial vencido de Railway, issue de infraestructura ajeno a esta tarjeta).