### PR TITLE
perf: cachear estadisticas del dashboard y extraer DashboardStatsServ…

### DIFF
--- a/app/Http/Controllers/DashboardController.php
+++ b/app/Http/Controllers/DashboardController.php
@@ -6,6 +6,7 @@ use App\Models\User;
 use App\Models\Appointment;
 use App\Models\ActivityLog;
 use App\Models\PatientProfile;
+use App\Services\DashboardStatsService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Carbon\Carbon;
@@ -29,70 +30,13 @@ class DashboardController extends Controller
 
 		abort(403);
 	}
+
 	/**
-	 * Dashboard del administrador
+	 * Dashboard del administrador — estadísticas cacheadas vía DashboardStatsService
 	 */
-	private function adminDashboard()
+	public function adminData(DashboardStatsService $stats)
 	{
-		$today = Carbon::today();
-		$thisMonth = Carbon::now()->startOfMonth();
-
-		$appointmentsToday = Appointment::whereDate('appointment_date', $today)->count();
-		$appointmentsMonth = Appointment::whereDate('appointment_date', '>=', $thisMonth)->count();
-		$pendingToday = Appointment::whereDate('appointment_date', $today)->where('status', 'pending')->count();
-
-		$recentAppointments = Appointment::with(['patient', 'doctor'])
-			->orderBy('appointment_date', 'desc')
-			->take(10)
-			->get()
-			->map(fn($a) => [
-				'patient'  => $a->patient ? $a->patient->name . ' ' . $a->patient->last_name : 'N/A',
-				'doctor'   => $a->doctor ? 'Dr. ' . $a->doctor->last_name : 'N/A',
-				'datetime' => $a->appointment_date . ' ' . $a->start_time,
-				'status'   => $a->status,
-			]);
-
-		$recentActivity = ActivityLog::with('user')
-			->orderBy('created_at', 'desc')
-			->take(5)
-			->get()
-			->map(fn($log) => [
-				'icon' => match ($log->action) {
-					'login'  => 'bi-box-arrow-in-right',
-					'logout' => 'bi-box-arrow-left',
-					'create' => 'bi-plus-circle',
-					'update' => 'bi-pencil-square',
-					'delete' => 'bi-trash',
-					default  => 'bi-info-circle',
-				},
-				'tone' => match ($log->action) {
-					'login'  => 'primary',
-					'logout' => 'secondary',
-					'create' => 'success',
-					'update' => 'warning',
-					'delete' => 'danger',
-					default  => 'info',
-				},
-				'text' => $log->description,
-				'time' => $log->created_at->diffForHumans(),
-			]);
-
-		return response()->json([
-			'stats' => [
-				'totalUsers'        => User::count(),
-				'appointmentsToday' => $appointmentsToday,
-				'activeDoctors'     => User::role('doctor')->count(),
-				'appointmentsMonth' => $appointmentsMonth,
-				'details' => [
-					'totalUsers'            => User::role('doctor')->count() . ' doctores, ' . User::role('patient')->count() . ' pacientes',
-					'appointmentsToday'     => $pendingToday . ' pendientes',
-					'activeDoctors'         => 'registrados',
-					'appointmentsMonth'     => 'este mes',
-				],
-			],
-			'recentAppointments' => $recentAppointments,
-			'activityLogs'       => $recentActivity,
-		]);
+		return response()->json($stats->adminStats());
 	}
 
 	/**
@@ -151,51 +95,27 @@ class DashboardController extends Controller
 	}
 
 	/**
-	 * Usuarios agrupados por fecha para gráfica (solo admin)
+	 * Usuarios agrupados por fecha para gráfica (solo admin) — cacheado
 	 */
-	public function getUsersChart(Request $request)
+	public function getUsersChart(Request $request, DashboardStatsService $stats)
 	{
 		if (!Auth::user()->hasRole('admin')) {
 			abort(403);
 		}
 
-		$query = User::selectRaw('DATE(created_at) as date, count(*) as total')
-			->groupBy('date')
-			->orderBy('date');
-
-		if ($request->filled('date_from')) {
-			$query->whereDate('created_at', '>=', $request->date_from);
-		}
-
-		if ($request->filled('date_to')) {
-			$query->whereDate('created_at', '<=', $request->date_to);
-		}
-
-		return response()->json($query->get());
+		return response()->json($stats->usersChart($request));
 	}
 
 	/**
-	 * Citas agrupadas por fecha y status para gráfica (solo admin)
+	 * Citas agrupadas por fecha y status para gráfica (solo admin) — cacheado
 	 */
-	public function getAppointmentsChart(Request $request)
+	public function getAppointmentsChart(Request $request, DashboardStatsService $stats)
 	{
 		if (!Auth::user()->hasRole('admin')) {
 			abort(403);
 		}
 
-		$query = Appointment::selectRaw('DATE(appointment_date) as date, status, count(*) as total')
-			->groupBy('date', 'status')
-			->orderBy('date');
-
-		if ($request->filled('date_from')) {
-			$query->whereDate('appointment_date', '>=', $request->date_from);
-		}
-
-		if ($request->filled('date_to')) {
-			$query->whereDate('appointment_date', '<=', $request->date_to);
-		}
-
-		return response()->json($query->get());
+		return response()->json($stats->appointmentsChart($request));
 	}
 
 	/**
@@ -213,11 +133,6 @@ class DashboardController extends Controller
 				->take(10)
 				->get()
 		);
-	}
-
-	public function adminData()
-	{
-		return $this->adminDashboard();
 	}
 
 	public function doctorData()

--- a/app/Services/DashboardStatsService.php
+++ b/app/Services/DashboardStatsService.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\ActivityLog;
+use App\Models\Appointment;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+
+class DashboardStatsService
+{
+	/**
+	 * TTL en segundos para las estadísticas generales del dashboard.
+	 */
+	private const STATS_TTL = 120;
+
+	/**
+	 * TTL en segundos para las gráficas.
+	 */
+	private const CHART_TTL = 300; // 5 minutos
+
+	/**
+	 * Estadísticas del dashboard de administrador, cacheadas.
+	 */
+	public function adminStats(): array
+	{
+		return Cache::remember('dashboard.admin.stats', self::STATS_TTL, function () {
+			return $this->buildAdminStats();
+		});
+	}
+
+	/**
+	 * Usuarios agrupados por fecha, cacheado por rango de fechas.
+	 */
+	public function usersChart(Request $request): array
+	{
+		$key = $this->chartCacheKey('dashboard.users-chart', $request);
+
+		return Cache::remember($key, self::CHART_TTL, function () use ($request) {
+			return $this->buildUsersChart($request);
+		});
+	}
+
+	/**
+	 * Citas agrupadas por fecha y status, cacheado por rango de fechas.
+	 */
+	public function appointmentsChart(Request $request): array
+	{
+		$key = $this->chartCacheKey('dashboard.appointments-chart', $request);
+
+		return Cache::remember($key, self::CHART_TTL, function () use ($request) {
+			return $this->buildAppointmentsChart($request);
+		});
+	}
+
+	/**
+	 * Construye las estadísticas del admin (lógica original, sin cambios de negocio).
+	 */
+	private function buildAdminStats(): array
+	{
+		$today = Carbon::today();
+		$thisMonth = Carbon::now()->startOfMonth();
+
+		$appointmentsToday = Appointment::whereDate('appointment_date', $today)->count();
+		$appointmentsMonth = Appointment::whereDate('appointment_date', '>=', $thisMonth)->count();
+		$pendingToday = Appointment::whereDate('appointment_date', $today)->where('status', 'pending')->count();
+
+		$recentAppointments = Appointment::with(['patient', 'doctor'])
+			->orderBy('appointment_date', 'desc')
+			->take(10)
+			->get()
+			->map(fn($a) => [
+				'patient' => $a->patient ? $a->patient->name . ' ' . $a->patient->last_name : 'N/A',
+				'doctor' => $a->doctor ? 'Dr. ' . $a->doctor->last_name : 'N/A',
+				'datetime' => $a->appointment_date . ' ' . $a->start_time,
+				'status' => $a->status,
+			]);
+
+		$recentActivity = ActivityLog::with('user')
+			->orderBy('created_at', 'desc')
+			->take(5)
+			->get()
+			->map(fn($log) => [
+				'icon' => match ($log->action) {
+					'login' => 'bi-box-arrow-in-right',
+					'logout' => 'bi-box-arrow-left',
+					'create' => 'bi-plus-circle',
+					'update' => 'bi-pencil-square',
+					'delete' => 'bi-trash',
+					default => 'bi-info-circle',
+				},
+				'tone' => match ($log->action) {
+					'login' => 'primary',
+					'logout' => 'secondary',
+					'create' => 'success',
+					'update' => 'warning',
+					'delete' => 'danger',
+					default => 'info',
+				},
+				'text' => $log->description,
+				'time' => $log->created_at->diffForHumans(),
+			]);
+
+		return [
+			'stats' => [
+				'totalUsers' => User::count(),
+				'appointmentsToday' => $appointmentsToday,
+				'activeDoctors' => User::role('doctor')->count(),
+				'appointmentsMonth' => $appointmentsMonth,
+				'details' => [
+					'totalUsers' => User::role('doctor')->count() . ' doctores, ' . User::role('patient')->count() . ' pacientes',
+					'appointmentsToday' => $pendingToday . ' pendientes',
+					'activeDoctors' => 'registrados',
+					'appointmentsMonth' => 'este mes',
+				],
+			],
+			'recentAppointments' => $recentAppointments->toArray(),
+			'activityLogs' => $recentActivity->toArray(),
+		];
+	}
+
+	private function buildUsersChart(Request $request): array
+	{
+		$query = User::selectRaw('DATE(created_at) as date, count(*) as total')
+			->groupBy('date')
+			->orderBy('date');
+
+		if ($request->filled('date_from')) {
+			$query->whereDate('created_at', '>=', $request->date_from);
+		}
+
+		if ($request->filled('date_to')) {
+			$query->whereDate('created_at', '<=', $request->date_to);
+		}
+
+		return $query->get()->toArray();
+	}
+
+	private function buildAppointmentsChart(Request $request): array
+	{
+		$query = Appointment::selectRaw('DATE(appointment_date) as date, status, count(*) as total')
+			->groupBy('date', 'status')
+			->orderBy('date');
+
+		if ($request->filled('date_from')) {
+			$query->whereDate('appointment_date', '>=', $request->date_from);
+		}
+
+		if ($request->filled('date_to')) {
+			$query->whereDate('appointment_date', '<=', $request->date_to);
+		}
+
+		return $query->get()->toArray();
+	}
+
+	/**
+	 * Genera una clave de cache única según el rango de fechas solicitado.
+	 */
+	private function chartCacheKey(string $prefix, Request $request): string
+	{
+		$from = $request->input('date_from', 'all');
+		$to = $request->input('date_to', 'all');
+
+		return "{$prefix}.{$from}.{$to}";
+	}
+}

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         "google/apiclient": "^2.16",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1",
+        "predis/predis": "^3.6",
         "spatie/laravel-permission": "^6.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f45909f57e50949a91f67a7f19e0bfa6",
+    "content-hash": "e3191adcde054d3f4391a6d8f1813c6c",
     "packages": [
         {
             "name": "brick/math",
@@ -3071,6 +3071,69 @@
                 }
             ],
             "time": "2026-01-27T09:17:28+00:00"
+        },
+        {
+            "name": "predis/predis",
+            "version": "v3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/predis/predis.git",
+                "reference": "2ff20c08bb63697245ffee3f198d1673086c302d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/predis/predis/zipball/2ff20c08bb63697245ffee3f198d1673086c302d",
+                "reference": "2ff20c08bb63697245ffee3f198d1673086c302d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "psr/http-message": "^1.0|^2.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.3",
+                "phpstan/phpstan": "^1.9",
+                "phpunit/phpcov": "^6.0 || ^8.0",
+                "phpunit/phpunit": "^8.0 || ~9.4.4"
+            },
+            "suggest": {
+                "ext-relay": "Faster connection with in-memory caching (>=0.6.2)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Till Krüss",
+                    "homepage": "https://till.im",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "A flexible and feature-complete Redis/Valkey client for PHP.",
+            "homepage": "http://github.com/predis/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/predis/predis/issues",
+                "source": "https://github.com/predis/predis/tree/v3.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/tillkruss",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-08-14T23:07:56+00:00"
         },
         {
             "name": "psr/cache",

--- a/tests/Unit/Services/DashboardStatsServiceTest.php
+++ b/tests/Unit/Services/DashboardStatsServiceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\DashboardStatsService;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+class DashboardStatsServiceTest extends TestCase
+{
+	public function test_admin_stats_uses_cache_remember_with_correct_key_and_ttl(): void
+	{
+		$expected = ['stats' => ['totalUsers' => 5]];
+
+		Cache::shouldReceive('remember')
+			->once()
+			->with('dashboard.admin.stats', 120, \Mockery::type('Closure'))
+			->andReturn($expected);
+
+		$service = new DashboardStatsService();
+
+		$result = $service->adminStats();
+
+		$this->assertSame($expected, $result);
+	}
+
+	public function test_users_chart_cache_key_differs_by_date_range(): void
+	{
+		$service = new DashboardStatsService();
+
+		$requestA = Request::create('/admin/dashboard/users-chart', 'GET', [
+			'date_from' => '2026-01-01',
+			'date_to' => '2026-06-30',
+		]);
+
+		$requestB = Request::create('/admin/dashboard/users-chart', 'GET', [
+			'date_from' => '2026-07-01',
+			'date_to' => '2026-12-31',
+		]);
+
+		Cache::shouldReceive('remember')
+			->once()
+			->with('dashboard.users-chart.2026-01-01.2026-06-30', 300, \Mockery::type('Closure'))
+			->andReturn(['rango' => 'A']);
+
+		Cache::shouldReceive('remember')
+			->once()
+			->with('dashboard.users-chart.2026-07-01.2026-12-31', 300, \Mockery::type('Closure'))
+			->andReturn(['rango' => 'B']);
+
+		$resultA = $service->usersChart($requestA);
+		$resultB = $service->usersChart($requestB);
+
+		$this->assertSame(['rango' => 'A'], $resultA);
+		$this->assertSame(['rango' => 'B'], $resultB);
+	}
+
+	public function test_appointments_chart_uses_cache_remember_with_ttl_of_five_minutes(): void
+	{
+		$service = new DashboardStatsService();
+
+		$request = Request::create('/admin/dashboard/appointments-chart', 'GET');
+
+		Cache::shouldReceive('remember')
+			->once()
+			->with('dashboard.appointments-chart.all.all', 300, \Mockery::type('Closure'))
+			->andReturn([['date' => '2026-08-01', 'status' => 'confirmed', 'total' => 2]]);
+
+		$result = $service->appointmentsChart($request);
+
+		$this->assertSame(
+			[['date' => '2026-08-01', 'status' => 'confirmed', 'total' => 2]],
+			$result
+		);
+	}
+}


### PR DESCRIPTION
# 🚀 Solicitud de Pull Request

## 📌 Resumen del Cambio
Se extrae la lógica del dashboard de administrador a un servicio dedicado (`DashboardStatsService`), cacheando las estadísticas generales (TTL 120s) y las gráficas de usuarios/citas (TTL 5 min, con clave por rango de fechas). `DashboardController::adminData()` queda reducido a 2 líneas, delegando toda la lógica al servicio.

## 🔍 Tipo de Cambio realizado
- [x] 🚀 Mejora de rendimiento (`perf`)
- [x] ♻️ Refactorización del código sin cambios funcionales (`refactor`)

## 📂 Archivos Afectados
- `app/Services/DashboardStatsService.php` (nuevo)
- `app/Http/Controllers/DashboardController.php`
- `tests/Unit/Services/DashboardStatsServiceTest.php` (nuevo)
- `composer.json` / `composer.lock` (se agrega `predis/predis`)

## 🧪 ¿Cómo Probarlo?
1. `php artisan test --filter=DashboardStatsServiceTest` → 3 pruebas unitarias en verde, con el cache mockeado (`Cache::shouldReceive`)
2. En `php artisan tinker`, con `DB::enableQueryLog()`: la primera llamada a `adminStats()` genera 19 queries; la segunda llamada (con el resultado ya cacheado) genera solo 1 (la consulta ligera al cache-store)
3. Confirmar con `$resultado1 === $stats->adminStats()` que el contenido servido desde cache es idéntico
4. Probar `usersChart()` con dos rangos de fecha distintos → cada uno genera su propia clave de cache y su propia consulta, sin mezclarse

## ✅ Checklist
- [x] He probado mis cambios localmente
- [x] Esta PR sigue el formato de convención de commits (si aplica)
- [x] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

## 📎 Notas Adicionales
Closes #55

Los 2 criterios de aceptación quedaron validados con evidencia: la caída de queries (19→1) confirma la mejora de rendimiento del dashboard, y las 3 pruebas unitarias con cache mockeado cubren el segundo criterio.

Nota de infraestructura (no bloqueante): la tarea de la auditoría también pedía activar Redis en Railway (`CACHE_STORE=redis`). El código es agnóstico al motor de cache (usa el facade `Cache::` de Laravel), por lo que funciona igual con `database` o `redis` sin cambios de código. El cambio de `CACHE_STORE` en Railway queda pendiente por el trial vencido de la plataforma (mismo bloqueante de PRs anteriores, ajeno a esta tarjeta).

Incluye instrucciones claras para probar los cambios localmente.

> Ejemplo:  
> 1. Ejecutar `npm install`  
> 2. Iniciar app con `npm run dev`  
> 3. Ir a `/login` y probar credenciales inválidas  
> 4. Revisar consola del navegador

---

## ✅ Checklist

Asegúrate de completar lo siguiente antes de enviar:

- [ ] He probado mis cambios localmente
- [ ] Esta PR sigue el formato de convención de commits (si aplica)
- [ ] Se han actualizado o agregado pruebas
- [ ] La documentación se actualizó si fue necesario
- [ ] No hay errores en CI/CD

---

## 📎 Notas Adicionales
<img width="1613" height="1190" alt="Captura desde 2026-08-19 19-09-43" src="https://github.com/user-attachments/assets/0ee6e49d-4fa5-4ba8-b621-e2ff3294b304" />



Agrega cualquier otro contexto útil o dependencias cruzadas con otros issues/PRs.

> Ejemplo: Este PR resuelve el issue #123  
> También se recomienda revisar el PR #456 para evitar conflictos.

---

Gracias 🙌
